### PR TITLE
Replaces shelling out to ping with the fastping package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Created by .ignore support plugin (hsz.mobi)
 .gitignore
 .idea/
+vendor
+build

--- a/main.go
+++ b/main.go
@@ -17,11 +17,17 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/IrekRomaniuk/snap-plugin-collector-pingscan/pingscan"
 	"github.com/intelsdi-x/snap/control/plugin"
-	"os"
 )
 
 func main() {
-	plugin.Start(pingscan.Meta(), pingscan.New(), os.Args[1],)
+	if os.Geteuid() != 0 {
+		fmt.Fprintf(os.Stderr, "Plugin must be run as root\n")
+		os.Exit(1)
+	}
+	plugin.Start(pingscan.Meta(), pingscan.New(), os.Args[1])
 }


### PR DESCRIPTION
Using fastping provides a simple interface that provides
handlers for success (and timeouts). Note the plugin needs
to be run as root (see https://github.com/tatsushid/go-fastping/issues/25).